### PR TITLE
redirect to panel according to role

### DIFF
--- a/app/Http/Middleware/RedirectToPanel.php
+++ b/app/Http/Middleware/RedirectToPanel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectToPanel
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {    
+        if (Auth::user() && Auth::user()->role->name === "Admin"){
+            return redirect("/admin");
+        }
+        if (Auth::user() && Auth::user()->role->name === "Moderator"){
+            return redirect("/moderator");
+        }
+        return $next($request);
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\RedirectToPanel;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -50,6 +51,7 @@ class AppPanelProvider extends PanelProvider
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+                RedirectToPanel::class,
             ])
             ->authMiddleware([
                 Authenticate::class,


### PR DESCRIPTION
not quality tested
Using middleware to only the AppPanelProvider which has a path of '/' and if the logged in user has a role of admin or moderator they will be redirected to it after logging in.

It may be better to remove the log in and register on the moderator and admin panel